### PR TITLE
Fixing "Exit hanging" bug

### DIFF
--- a/tello/drone_commander.py
+++ b/tello/drone_commander.py
@@ -36,7 +36,7 @@ def init_drone():
     except socket.error as err:
         print(err)
 
-    recvThread = threading.Thread(target=recv)
+    recvThread = threading.Thread(target=recv, daemon=True)
     recvThread.start()
 
     print('==> Connection Established')
@@ -93,7 +93,7 @@ def main():
 
         cmd = input('D R O N E >> ')
         if cmd == 'exit':
-            break
+            print('==> Exiting ...')
             exit(0)
         elif cmd =='help':
             help()


### PR DESCRIPTION
In the last version, the "exit" command would simply hang. By changing the thread to a daemon, exit(0) at the end will exit the program properly. This improves testing speed and error logging for debugging. (No new command windows to start the tool)